### PR TITLE
Improved phase interpolation

### DIFF
--- a/components/algo_common/algo_common.h
+++ b/components/algo_common/algo_common.h
@@ -19,6 +19,8 @@
 #define FFT_MOD_SIZE (N_SAMPLES/2 + 1) // Number of samples for modification, ie up to Nyquist
 #define I2S_VOLTAGE_CONV (3.576279113e-7) // 3.0 V / max I2S (1 << 23 - 1)
 
+#define TWO_M_PI (6.28318530718) // For ease of reference
+
 // Useful for flag arrays
 #define SET_ARR_BIT(arr, idx, val) (arr[(idx)/8] |= ((val) ? 1 : 0) << ((idx) % 8))
 #define GET_ARR_BIT(arr, idx)      ((arr[(idx)/8] >> ((idx) % 8)) & 0x1)

--- a/components/filters/filters.h
+++ b/components/filters/filters.h
@@ -1,7 +1,7 @@
 #ifndef __FILTERS_H__
 #define __FILTERS_H__
 
-#define TRUE_ENV_NUM_ITERATIONS (3)   // Should be close enough for near convergence
+#define TRUE_ENV_NUM_ITERATIONS (4)   // Should be close enough for near convergence
 #define CEPSTRUM_LEN            (N_SAMPLES / 2) // Half size for lower footprint and quicker calculations
 #define CEPSTRUM_MOD_SIZE       (CEPSTRUM_LEN / 2 + 1) // Half again for magnitude
 

--- a/components/phase_vocoder_algo/peak_shift/peak_shift.c
+++ b/components/phase_vocoder_algo/peak_shift/peak_shift.c
@@ -158,7 +158,7 @@ float _get_true_env_correction(int old_idx, int new_idx)
   return true_env_gain;
 }
 
-void shift_peaks(float shift_factor, float shift_gain)
+void shift_peaks(float shift_factor, float shift_gain, float true_env_scale)
 {
   // First check if unity.
   // If so, simply add to output FFT
@@ -246,7 +246,8 @@ void shift_peaks(float shift_factor, float shift_gain)
       // FIXME: might be worth having some sort of linear slope when below fundamental, instead of hard cliff
       int new_bin_idx  = new_idx / 2;
       int orig_bin_idx = orig_idx / 2;
-      float true_env_corr = _get_true_env_correction(orig_bin_idx, new_bin_idx);
+      float true_env_corr = true_env_scale * _get_true_env_correction(orig_bin_idx, new_bin_idx);
+      true_env_corr += (1 - true_env_scale);
 
       // Add to output FFT at new index, now applying shift_gain and true envelope correction
       // to both real and imaginary components

--- a/components/phase_vocoder_algo/peak_shift/peak_shift.h
+++ b/components/phase_vocoder_algo/peak_shift/peak_shift.h
@@ -28,7 +28,7 @@ typedef struct {
   float* fft_prev_ptr;        // Pointer to input FFT array of previous frame (size N+2)
   float* fft_mag_ptr;         // Pointer to input FFT magnitude array of current frame (size N/2+1)
   float* fft_out_ptr;         // Pointer to output FFT (size 2*N)
-  float* fft_out_prev_phase;  // Pointer to output FFT phase for previous frame
+  float* fft_out_prev_ptr;    // Pointer to output FFT for previous frame
   float* true_env_ptr;        // Pointer to true envelope buffer (calculated externally)
   float* inv_env_ptr;         // Pointer to inverse of true envelope (i.e. 1/true_env above)
 } peak_shift_cfg_t;
@@ -42,6 +42,9 @@ typedef struct {
  *              relevant arrays
  */
 void init_peak_shift_cfg(peak_shift_cfg_t* cfg);
+
+// TODO fill docstring
+void reset_phase_comp_arr(float* phase_comp);
 
 /**
  * @brief Locate peaks within FFT magnitude plot

--- a/components/phase_vocoder_algo/peak_shift/peak_shift.h
+++ b/components/phase_vocoder_algo/peak_shift/peak_shift.h
@@ -28,6 +28,7 @@ typedef struct {
   float* fft_prev_ptr;        // Pointer to input FFT array of previous frame (size N+2)
   float* fft_mag_ptr;         // Pointer to input FFT magnitude array of current frame (size N/2+1)
   float* fft_out_ptr;         // Pointer to output FFT (size 2*N)
+  float* fft_out_prev_phase;  // Pointer to output FFT phase for previous frame
   float* true_env_ptr;        // Pointer to true envelope buffer (calculated externally)
   float* inv_env_ptr;         // Pointer to inverse of true envelope (i.e. 1/true_env above)
 } peak_shift_cfg_t;
@@ -41,17 +42,6 @@ typedef struct {
  *              relevant arrays
  */
 void init_peak_shift_cfg(peak_shift_cfg_t* cfg);
-
-/**
- * @brief Reset cumulative phase compensation array
- * 
- * Sets all complex values to 1 + 0j
- * Needs to be a pointer in the case of chorus effect (multiple pitch shifts)
- * 
- * @param run_phase_comp_ptr - Pointer to running phase compensation array.
- *                             Should be cfg->num_samples in length
- */
-void reset_phase_comp_arr(float* run_phase_comp_ptr);
 
 /**
  * @brief Locate peaks within FFT magnitude plot
@@ -99,8 +89,7 @@ float est_fundamental_freq(void);
  * 
  * @param shift_factor - Factor by which to shift frequency data
  * @param gain - Gain applied to shifted peaks
- * @param run_phase_comp_ptr - Pointer to array containing running phase rotation data
  */
-void shift_peaks(float shift_factor, float gain, float* run_phase_comp_ptr);
+void shift_peaks(float shift_factor, float gain);
 
 #endif // __PEAK_SHIFT__

--- a/components/phase_vocoder_algo/peak_shift/peak_shift.h
+++ b/components/phase_vocoder_algo/peak_shift/peak_shift.h
@@ -43,7 +43,14 @@ typedef struct {
  */
 void init_peak_shift_cfg(peak_shift_cfg_t* cfg);
 
-// TODO fill docstring
+/**
+ * @brief Reset phase compensation array
+ * 
+ * Sets to polar unity (real = 1, imag = 0)
+ * Assumes size of FFT_MOD_SIZE x 2 (or half FFT size, doubled for real+imag)
+ * 
+ * @param phase_comp - Phase compensation array
+ */
 void reset_phase_comp_arr(float* phase_comp);
 
 /**
@@ -92,7 +99,8 @@ float est_fundamental_freq(void);
  * 
  * @param shift_factor - Factor by which to shift frequency data
  * @param gain - Gain applied to shifted peaks
+ * @param true_env_scale - Scaling factor for true envelope correction
  */
-void shift_peaks(float shift_factor, float gain);
+void shift_peaks(float shift_factor, float gain, float true_env_scale);
 
 #endif // __PEAK_SHIFT__

--- a/main/esp_vocoder_main.h
+++ b/main/esp_vocoder_main.h
@@ -67,6 +67,7 @@ float rx_env_inv[FFT_MOD_SIZE]; // Inverse for ratio calc
 static Yin yin_s;
 static float yinBuffPtr[YIN_SAMPLES / 2];
 float yin_f0_est;
+float yin_f0_prob;
 
 #define NOISE_THRESHOLD_DB  (14) // Empirical
 #define SILENCE_RESET_COUNT (10) // every quarter second
@@ -145,13 +146,16 @@ static const float PITCH_SHIFT_GAINS[] = {
   1.0, // Lower sixth flat
   0.8, // Minor third
 };
+#define CHORUS_SCALE      (1.0)
 
-#define LOW_EFFECT_SHIFT  (0.5)
+#define LOW_EFFECT_SHIFT  (0.75)
 #define LOW_EFFECT_GAIN   (1.2)
+#define LOW_EFFECT_SCALE  (0.2)
 #define HIGH_EFFECT_SHIFT (2.0)
 #define HIGH_EFFECT_GAIN  (1.0)
-#define PASSTHROUGH_SHIFT (1.0)
-#define PASSTHROUGH_GAIN  (1.0)
+#define HIGH_EFFECT_SCALE (1.0)
+#define AUTOTUNE_GAIN     (1.0)
+#define AUTOTUNE_SCALE    (1.0)
 
 
 typedef enum {

--- a/main/esp_vocoder_main.h
+++ b/main/esp_vocoder_main.h
@@ -51,11 +51,9 @@ int N = N_SAMPLES;
 __attribute__((aligned(16))) float rx_FFT[N_SAMPLES * 2]; // Will be complex
 __attribute__((aligned(16))) float tx_iFFT[N_SAMPLES * 2];
 __attribute__((aligned(16))) float prev_rx_FFT[FFT_MOD_SIZE * 2]; // For inst freq calc
+__attribute__((aligned(16))) float prev_tx_FFT[FFT_MOD_SIZE * 2];
 // Peak shift buffers
 float rx_FFT_mag[FFT_MOD_SIZE]; // Needed for peak shifting
-float prev_tx_FFT_phase[FFT_MOD_SIZE]; // Needed for phase propagation
-// Helper for resetting previous TX phase (same as zero-ing out running comp)
-#define RESET_TX_PHASE (memset(prev_tx_FFT_phase, 0, FFT_MOD_SIZE * sizeof(float)))
 // True envelope buffers
 // Use tx_iFFT to save memory for envelope FFT/cepstrum buffers
 float* env_FFT = tx_iFFT;

--- a/main/esp_vocoder_main.h
+++ b/main/esp_vocoder_main.h
@@ -53,7 +53,9 @@ __attribute__((aligned(16))) float tx_iFFT[N_SAMPLES * 2];
 __attribute__((aligned(16))) float prev_rx_FFT[FFT_MOD_SIZE * 2]; // For inst freq calc
 // Peak shift buffers
 float rx_FFT_mag[FFT_MOD_SIZE]; // Needed for peak shifting
-float run_phase_comp[FFT_MOD_SIZE * 2]; // Cumulative phase compensation buffer
+float prev_tx_FFT_phase[FFT_MOD_SIZE]; // Needed for phase propagation
+// Helper for resetting previous TX phase (same as zero-ing out running comp)
+#define RESET_TX_PHASE (memset(prev_tx_FFT_phase, 0, FFT_MOD_SIZE * sizeof(float)))
 // True envelope buffers
 // Use tx_iFFT to save memory for envelope FFT/cepstrum buffers
 float* env_FFT = tx_iFFT;
@@ -68,8 +70,8 @@ static Yin yin_s;
 static float yinBuffPtr[YIN_SAMPLES / 2];
 float yin_f0_est;
 
-#define NOISE_THRESHOLD_DB (14) // Empirical
-#define SILENCE_RESET_COUNT (5) // ~every quarter second
+#define NOISE_THRESHOLD_DB  (14) // Empirical
+#define SILENCE_RESET_COUNT (10) // every quarter second
 
 // TX/RX buffers
 #define DELAY_TAP_SIZE   (0) // No delay tap for now


### PR DESCRIPTION
Changed the phase propagation calculation to instead use the previous output FFT phase and improve phase interpolation.
Pitch shifting is now much more accurate.
Also reduced low pitch true envelope influence and reduced downshift, for more pronounced but understandable effect (i.e. unflattened by frequency resolution).